### PR TITLE
Update annotation_create-annotations_span_forward.adoc

### DIFF
--- a/webanno-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_span_forward.adoc
+++ b/webanno-ui-annotation/src/main/resources/META-INF/asciidoc/user-guide/annotation_create-annotations_span_forward.adoc
@@ -42,7 +42,7 @@ annotation and moves on. Otherwise the current annotation is removed if the feat
 
 Press *ENTER* to complete the annotation and to move on to the next token. In the general case, 
 a new annotation is created on the next token and it is loaded into the feature editor. However, 
-if stacking or overlapping annotations not permitted and if there is already an annotation on that
+if stacking or overlapping annotations is not permitted and if there is already an annotation on that
 token, this would naturally fail. In this case, no new annotation is created and instead an existing annotation is opened for
 editing. 
 


### PR DESCRIPTION
I believe that "is" is the correct form here (and that the intended meaning is "if it is not permitted to stack annotations or make them overlap"). However, maybe things could get a bit clearer with an added positive statement, saying something like >>(i.e., if the value of the behaviour setting for Overlap is set to anything else than "Any")<<

**What's in the PR**
* ...

**How to test manually**
* ...

**Automatic testing**
* [ ] PR includes unit tests

**Documentation**
* [ ] PR updates documentation
